### PR TITLE
Reassign ids and remap referenced cells if necessary on paste

### DIFF
--- a/dfkernel/resources/df-notebook/utils.js
+++ b/dfkernel/resources/df-notebook/utils.js
@@ -15,9 +15,23 @@ define(function() {
         var num = Math.floor(Math.random() * parseInt("f".repeat(len), 16)) + 1;
         return pad_str_left(num.toString(16), len);
     };
-    
+
+    var CODE_REGEX = /(^|[^A-Za-z0-9_])Out\[[\'\"]([0-9a-f]+)[\'\"]\]/g;
+
+    var rewrite_code_ids = function(code, map) {
+        // replace allows a function that passes parenthesized submatches
+        return code.replace(CODE_REGEX, function(s, g1, g2) {
+            if (g2 in map) {
+                return g1 + "Out['" + map[g2] + "']";
+            } else {
+                return s;
+            }
+        });
+    };
+
     return {
         pad_str_left: pad_str_left,
-        random_hex_str: random_hex_str
+        random_hex_str: random_hex_str,
+        rewrite_code_ids: rewrite_code_ids
     };
 });


### PR DESCRIPTION
Address #10 by remapping ids when a cells are pasted. If a cell id already exists, the pasted cell gets a new id. If the code of a cell in the pasted block references cells that were remapped (assigned a new id), those references are rewritten using a regex. References to cells that were not remapped are not reassigned.

The regex searches for `Out['[a-f0-9]+']` that are not preceded by a valid identifier character (so `myOut['ab']` is not remapped) and allows either single or double-quotes. It probably should allow whitespace...