### PR TITLE
Allow Out[...] references to omit quotes

### DIFF
--- a/dfkernel/resources/df-notebook/completer.js
+++ b/dfkernel/resources/df-notebook/completer.js
@@ -103,7 +103,7 @@ define([
         var cell_matches = this.add_cell_ids(this.editor.getValue(), start, end);
         cell_matches.forEach(function(cid) {
             filtered_results.unshift({
-                str: "Out['" + cid + "']",
+                str: "Out[" + cid + "]",
                 type: "cell_id",
                 from: from,
                 to: to

--- a/dfkernel/resources/df-notebook/utils.js
+++ b/dfkernel/resources/df-notebook/utils.js
@@ -25,7 +25,7 @@ define(function() {
         }
     };
 
-    var CODE_REGEX = /(^|[^A-Za-z0-9_])Out\[[\'\"]([0-9a-f]+)[\'\"]\]/g;
+    var CODE_REGEX = /(^|[^A-Za-z0-9_])Out\[[\'\"]?([0-9a-f]+)[\'\"]?\]/g;
 
     var rewrite_code_ids = function(code, map) {
         // replace allows a function that passes parenthesized submatches

--- a/dfkernel/resources/df-notebook/utils.js
+++ b/dfkernel/resources/df-notebook/utils.js
@@ -31,7 +31,7 @@ define(function() {
         // replace allows a function that passes parenthesized submatches
         return code.replace(CODE_REGEX, function(s, g1, g2) {
             if (g2 in map) {
-                return g1 + "Out['" + map[g2] + "']";
+                return g1 + "Out[" + map[g2] + "]";
             } else {
                 return s;
             }

--- a/dfkernel/resources/df-notebook/utils.js
+++ b/dfkernel/resources/df-notebook/utils.js
@@ -9,11 +9,20 @@ define(function() {
         return (pad_char.repeat(len) + s).substr(-len);
     };
 
-    var random_hex_str = function(len) {
+    var random_hex_str = function(len, start_letter) {
+        var num;
         len = (typeof len !== 'undefined') ? len : 6;
-        // generate value in [1, 0xf...f]
-        var num = Math.floor(Math.random() * parseInt("f".repeat(len), 16)) + 1;
-        return pad_str_left(num.toString(16), len);
+        if (start_letter || (start_letter === undefined)) {
+            var start_num = parseInt("a" + "0".repeat(len-1), 16);
+             num = Math.floor(Math.random() *
+                    (parseInt("f".repeat(len), 16) - start_num)) + start_num;
+            // no need to pad
+            return num.toString(16);
+        } else {
+            // generate value in [1, 0xf...f]
+            num = Math.floor(Math.random() * parseInt("f".repeat(len), 16)) + 1;
+            return pad_str_left(num.toString(16), len);
+        }
     };
 
     var CODE_REGEX = /(^|[^A-Za-z0-9_])Out\[[\'\"]([0-9a-f]+)[\'\"]\]/g;


### PR DESCRIPTION
Add the ability to reference cells without quotes using AST transform. This requires cells to start with a character (a-f for hexadecimal identifiers). This makes typing the references easier and matches how the `Out[...]` headings in the left margin are formatted.