### PR TITLE
Make 3.6 and 3.7 compatible again

### DIFF
--- a/dfkernel/tests/test_i18n.py
+++ b/dfkernel/tests/test_i18n.py
@@ -1,10 +1,7 @@
-import nose.tools as nt
-
 from notebook import i18n
 
 def test_parse_accept_lang_header():
     palh = i18n.parse_accept_lang_header
-    nt.assert_equal(palh(''), [])
-    nt.assert_equal(palh('zh-CN,en-GB;q=0.7,en;q=0.3'),
-                    ['en', 'en_GB', 'zh_CN'])
-    nt.assert_equal(palh('nl,fr;q=0'), ['nl'])
+    assert palh('') == []
+    assert palh('zh-CN,en-GB;q=0.7,en;q=0.3') == ['en', 'en_GB', 'zh', 'zh_CN']
+    assert palh('nl,fr;q=0') == ['nl']

--- a/dfkernel/tests/test_kernel.py
+++ b/dfkernel/tests/test_kernel.py
@@ -1,24 +1,28 @@
-# coding: utf-8
 """test the IPython Kernel"""
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import ast
 import io
 import os.path
 import sys
 import time
 
 import nose.tools as nt
+from flaky import flaky
+import pytest
+from packaging import version
 
 from IPython.testing import decorators as dec, tools as tt
-from ipython_genutils import py3compat
+import IPython
 from IPython.paths import locate_profile
 from ipython_genutils.tempdir import TemporaryDirectory
 
 from .utils import (
     new_kernel, kernel, TIMEOUT, assemble_output, execute,
-    flush_channels, wait_for_idle)
+    flush_channels, wait_for_idle, get_reply,
+)
 
 
 def _check_master(kc, expected=True, stream="stdout"):
@@ -26,13 +30,13 @@ def _check_master(kc, expected=True, stream="stdout"):
     flush_channels(kc)
     msg_id, content = execute(kc=kc, code="print (sys.%s._is_master_process())" % stream)
     stdout, stderr = assemble_output(kc.iopub_channel)
-    nt.assert_equal(stdout.strip(), repr(expected))
+    assert stdout.strip() == repr(expected)
 
 
 def _check_status(content):
     """If status=error, show the traceback"""
     if content['status'] == 'error':
-        nt.assert_true(False, ''.join(['\n'] + content['traceback']))
+        assert False, ''.join(['\n'] + content['traceback'])
 
 
 # printing tests
@@ -43,27 +47,41 @@ def test_simple_print():
         iopub = kc.iopub_channel
         msg_id, content = execute(kc=kc, code="print ('hi')")
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, 'hi\n')
-        nt.assert_equal(stderr, '')
+        assert stdout == 'hi\n'
+        assert stderr == ''
         _check_master(kc, expected=True)
 
 
 def test_sys_path():
     """test that sys.path doesn't get messed up by default"""
     with kernel() as kc:
-        msg_id, content = execute(kc=kc, code="import sys; print (repr(sys.path[0]))")
+        msg_id, content = execute(kc=kc, code="import sys; print(repr(sys.path))")
         stdout, stderr = assemble_output(kc.iopub_channel)
-        nt.assert_equal(stdout, "''\n")
+    # for error-output on failure
+    sys.stderr.write(stderr)
+
+    sys_path = ast.literal_eval(stdout.strip())
+    assert '' in sys_path
+
 
 def test_sys_path_profile_dir():
     """test that sys.path doesn't get messed up when `--profile-dir` is specified"""
 
     with new_kernel(['--profile-dir', locate_profile('default')]) as kc:
-        msg_id, content = execute(kc=kc, code="import sys; print (repr(sys.path[0]))")
+        msg_id, content = execute(kc=kc, code="import sys; print(repr(sys.path))")
         stdout, stderr = assemble_output(kc.iopub_channel)
-        nt.assert_equal(stdout, "''\n")
+    # for error-output on failure
+    sys.stderr.write(stderr)
 
-@dec.skipif(sys.platform == 'win32', "subprocess prints fail on Windows")
+    sys_path = ast.literal_eval(stdout.strip())
+    assert '' in sys_path
+
+
+@flaky(max_runs=3)
+@dec.skipif(
+    sys.platform == 'win32' or (sys.platform == "darwin" and sys.version_info >=(3, 8)),
+    "subprocess prints fail on Windows and MacOS Python 3.8+"
+)
 def test_subprocess_print():
     """printing from forked mp.Process"""
     with new_kernel() as kc:
@@ -73,7 +91,6 @@ def test_subprocess_print():
         flush_channels(kc)
         np = 5
         code = '\n'.join([
-            "from __future__ import print_function",
             "import time",
             "import multiprocessing as mp",
             "pool = [mp.Process(target=print, args=('hello', i,)) for i in range(%i)]" % np,
@@ -87,11 +104,12 @@ def test_subprocess_print():
         nt.assert_equal(stdout.count("hello"), np, stdout)
         for n in range(np):
             nt.assert_equal(stdout.count(str(n)), 1, stdout)
-        nt.assert_equal(stderr, '')
+        assert stderr == ''
         _check_master(kc, expected=True)
         _check_master(kc, expected=True, stream="stderr")
 
 
+@flaky(max_runs=3)
 def test_subprocess_noprint():
     """mp.Process without print doesn't trigger iostream mp_mode"""
     with kernel() as kc:
@@ -107,14 +125,18 @@ def test_subprocess_noprint():
 
         msg_id, content = execute(kc=kc, code=code)
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, '')
-        nt.assert_equal(stderr, '')
+        assert stdout == ''
+        assert stderr == ''
 
         _check_master(kc, expected=True)
         _check_master(kc, expected=True, stream="stderr")
 
 
-@dec.skipif(sys.platform == 'win32', "subprocess prints fail on Windows")
+@flaky(max_runs=3)
+@dec.skipif(
+    sys.platform == 'win32' or (sys.platform == "darwin" and sys.version_info >=(3, 8)),
+    "subprocess prints fail on Windows and MacOS Python 3.8+"
+)
 def test_subprocess_error():
     """error in mp.Process doesn't crash"""
     with new_kernel() as kc:
@@ -129,8 +151,8 @@ def test_subprocess_error():
 
         msg_id, content = execute(kc=kc, code=code)
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, '')
-        nt.assert_true("ValueError" in stderr, stderr)
+        assert stdout == ''
+        assert "ValueError" in stderr
 
         _check_master(kc, expected=True)
         _check_master(kc, expected=True, stream="stderr")
@@ -138,45 +160,24 @@ def test_subprocess_error():
 # raw_input tests
 
 def test_raw_input():
-    """test [raw_]input"""
+    """test input"""
     with kernel() as kc:
         iopub = kc.iopub_channel
 
-        input_f = "input" if py3compat.PY3 else "raw_input"
+        input_f = "input"
         theprompt = "prompt> "
         code = 'print({input_f}("{theprompt}"))'.format(**locals())
         msg_id = kc.execute(code, allow_stdin=True)
         msg = kc.get_stdin_msg(block=True, timeout=TIMEOUT)
-        nt.assert_equal(msg['header']['msg_type'], u'input_request')
+        assert msg['header']['msg_type'] == 'input_request'
         content = msg['content']
-        nt.assert_equal(content['prompt'], theprompt)
+        assert content['prompt'] == theprompt
         text = "some text"
         kc.input(text)
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
-        nt.assert_equal(reply['content']['status'], 'ok')
+        assert reply['content']['status'] == 'ok'
         stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, text + "\n")
-
-
-@dec.skipif(py3compat.PY3)
-def test_eval_input():
-    """test input() on Python 2"""
-    with kernel() as kc:
-        iopub = kc.iopub_channel
-
-        input_f = "input" if py3compat.PY3 else "raw_input"
-        theprompt = "prompt> "
-        code = 'print(input("{theprompt}"))'.format(**locals())
-        msg_id = kc.execute(code, allow_stdin=True)
-        msg = kc.get_stdin_msg(block=True, timeout=TIMEOUT)
-        nt.assert_equal(msg['header']['msg_type'], u'input_request')
-        content = msg['content']
-        nt.assert_equal(content['prompt'], theprompt)
-        kc.input("1+1")
-        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
-        nt.assert_equal(reply['content']['status'], 'ok')
-        stdout, stderr = assemble_output(iopub)
-        nt.assert_equal(stdout, "2\n")
+        assert stdout == text + "\n"
 
 
 def test_save_history():
@@ -184,23 +185,23 @@ def test_save_history():
     # unicode problems on Python 2.
     with kernel() as kc, TemporaryDirectory() as td:
         file = os.path.join(td, 'hist.out')
-        execute(u'a=1', kc=kc)
+        execute('a=1', kc=kc)
         wait_for_idle(kc)
-        execute(u'b=u"abcþ"', kc=kc)
+        execute('b="abcþ"', kc=kc)
         wait_for_idle(kc)
         _, reply = execute("%hist -f " + file, kc=kc)
-        nt.assert_equal(reply['status'], 'ok')
+        assert reply['status'] == 'ok'
         with io.open(file, encoding='utf-8') as f:
             content = f.read()
-        nt.assert_in(u'a=1', content)
-        nt.assert_in(u'b=u"abcþ"', content)
+        assert 'a=1' in content
+        assert 'b="abcþ"' in content
 
 
 @dec.skip_without('faulthandler')
 def test_smoke_faulthandler():
     with kernel() as kc:
         # Note: faulthandler.register is not available on windows.
-        code = u'\n'.join([
+        code = '\n'.join([
             'import sys',
             'import faulthandler',
             'import signal',
@@ -224,7 +225,7 @@ def test_is_complete():
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
         assert reply['content']['status'] == 'complete'
 
-        # SyntaxError should mean it's complete
+        # SyntaxError
         kc.is_complete('raise = 2')
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
         assert reply['content']['status'] == 'invalid'
@@ -234,22 +235,37 @@ def test_is_complete():
         assert reply['content']['status'] == 'incomplete'
         assert reply['content']['indent'] == ''
 
+        # Cell magic ends on two blank lines for console UIs
+        kc.is_complete('%%timeit\na\n\n')
+        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        assert reply['content']['status'] == 'complete'
 
+
+@dec.skipif(sys.platform != 'win32', "only run on Windows")
 def test_complete():
     with kernel() as kc:
-        execute(u'a = 1', kc=kc)
+        execute('a = 1', kc=kc)
         wait_for_idle(kc)
         cell = 'import IPython\nb = a.'
         kc.complete(cell)
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
-        c = reply['content']
-        nt.assert_equal(c['status'], 'ok')
-        nt.assert_equal(c['cursor_start'], cell.find('a.'))
-        nt.assert_equal(c['cursor_end'], cell.find('a.') + 2)
-        matches = c['matches']
-        nt.assert_greater(len(matches), 0)
-        for match in matches:
-            nt.assert_equal(match[:2], 'a.')
+
+    c = reply['content']
+    assert c['status'] == 'ok'
+    start = cell.find('a.')
+    end = start + 2
+    assert c['cursor_end'] == cell.find('a.') + 2
+    assert c['cursor_start'] <= end
+
+    # there are many right answers for cursor_start,
+    # so verify application of the completion
+    # rather than the value of cursor_start
+
+    matches = c['matches']
+    assert matches
+    for m in matches:
+        completed = cell[:c['cursor_start']] + m
+        assert completed.startswith(cell)
 
 
 @dec.skip_without('matplotlib')
@@ -265,19 +281,111 @@ def test_matplotlib_inline_on_import():
         _check_status(reply)
         backend_bundle = reply['user_expressions']['backend']
         _check_status(backend_bundle)
-        nt.assert_in('backend_inline', backend_bundle['data']['text/plain'])
+        assert 'backend_inline' in backend_bundle['data']['text/plain']
+
+
+def test_message_order():
+    N = 100  # number of messages to test
+    with kernel() as kc:
+        _, reply = execute("a = 1", kc=kc)
+        _check_status(reply)
+        offset = reply['execution_count'] + 1
+        cell = "a += 1\na"
+        msg_ids = []
+        # submit N executions as fast as we can
+        for i in range(N):
+            msg_ids.append(kc.execute(cell))
+        # check message-handling order
+        for i, msg_id in enumerate(msg_ids, offset):
+            reply = kc.get_shell_msg(timeout=TIMEOUT)
+            _check_status(reply['content'])
+            assert reply['content']['execution_count'] == i
+            assert reply['parent_header']['msg_id'] == msg_id
+
+
+@dec.skipif(sys.platform.startswith('linux') or sys.platform.startswith('darwin'))
+def test_unc_paths():
+    with kernel() as kc, TemporaryDirectory() as td:
+        drive_file_path = os.path.join(td, 'unc.txt')
+        with open(drive_file_path, 'w+') as f:
+            f.write('# UNC test')
+        unc_root = '\\\\localhost\\C$'
+        file_path = os.path.splitdrive(os.path.dirname(drive_file_path))[1]
+        unc_file_path = os.path.join(unc_root, file_path[1:])
+
+        iopub = kc.iopub_channel
+
+        kc.execute("cd {0:s}".format(unc_file_path))
+        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        assert reply['content']['status'] == 'ok'
+        out, err = assemble_output(iopub)
+        assert unc_file_path in out
+
+        flush_channels(kc)
+        kc.execute(code="ls")
+        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        assert reply['content']['status'] == 'ok'
+        out, err = assemble_output(iopub)
+        assert 'unc.txt' in out
+
+        kc.execute(code="cd")
+        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        assert reply['content']['status'] == 'ok'
 
 
 def test_shutdown():
     """Kernel exits after polite shutdown_request"""
     with new_kernel() as kc:
         km = kc.parent
-        execute(u'a = 1', kc=kc)
+        execute('a = 1', kc=kc)
         wait_for_idle(kc)
         kc.shutdown()
-        for i in range(100): # 10s timeout
+        for i in range(300): # 30s timeout
             if km.is_alive():
                 time.sleep(.1)
             else:
                 break
-        nt.assert_false(km.is_alive())
+        assert not km.is_alive()
+
+
+def test_interrupt_during_input():
+    """
+    The kernel exits after being interrupted while waiting in input().
+    input() appears to have issues other functions don't, and it needs to be
+    interruptible in order for pdb to be interruptible.
+    """
+    with new_kernel() as kc:
+        km = kc.parent
+        msg_id = kc.execute("input()")
+        time.sleep(1)  # Make sure it's actually waiting for input.
+        km.interrupt_kernel()
+        from .test_message_spec import validate_message
+        # If we failed to interrupt interrupt, this will timeout:
+        reply = get_reply(kc, msg_id, TIMEOUT)
+        validate_message(reply, 'execute_reply', msg_id)
+
+
+@pytest.mark.skipif(
+    version.parse(IPython.__version__) < version.parse("7.14.0"),
+    reason="Need new IPython"
+)
+def test_interrupt_during_pdb_set_trace():
+    """
+    The kernel exits after being interrupted while waiting in pdb.set_trace().
+    Merely testing input() isn't enough, pdb has its own issues that need
+    to be handled in addition.
+    This test will fail with versions of IPython < 7.14.0.
+    """
+    with new_kernel() as kc:
+        km = kc.parent
+        msg_id = kc.execute("import pdb; pdb.set_trace()")
+        msg_id2 = kc.execute("3 + 4")
+        time.sleep(1)  # Make sure it's actually waiting for input.
+        km.interrupt_kernel()
+        from .test_message_spec import validate_message
+        # If we failed to interrupt interrupt, this will timeout:
+        reply = get_reply(kc, msg_id, TIMEOUT)
+        validate_message(reply, 'execute_reply', msg_id)
+        # If we failed to interrupt interrupt, this will timeout:
+        reply = get_reply(kc, msg_id2, TIMEOUT)
+        validate_message(reply, 'execute_reply', msg_id2)

--- a/dfkernel/tests/test_nbextensions.py
+++ b/dfkernel/tests/test_nbextensions.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Test installation of notebook extensions"""
 
 # Copyright (c) Jupyter Development Team.
@@ -6,6 +5,7 @@
 
 import glob
 import os
+import pytest
 import sys
 import tarfile
 import zipfile
@@ -14,28 +14,25 @@ from os.path import basename, join as pjoin
 from traitlets.tests.utils import check_help_all_output
 from unittest import TestCase
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch # py2
+from unittest.mock import patch
 
 import ipython_genutils.testing.decorators as dec
 from ipython_genutils import py3compat
 from ipython_genutils.tempdir import TemporaryDirectory
 from notebook import nbextensions
 from notebook.nbextensions import (install_nbextension, check_nbextension,
-    enable_nbextension, disable_nbextension,
-    install_nbextension_python, uninstall_nbextension_python,
-    enable_nbextension_python, disable_nbextension_python, _get_config_dir,
-    validate_nbextension, validate_nbextension_python
-)
+                                   enable_nbextension, disable_nbextension,
+                                   install_nbextension_python, uninstall_nbextension_python,
+                                   enable_nbextension_python, disable_nbextension_python, _get_config_dir,
+                                   validate_nbextension, validate_nbextension_python
+                                   )
 
 from notebook.config_manager import BaseJSONConfigManager
 
 
 def touch(file_name, mtime=None):
     """ensure a file exists, and set its modification time
-    
+
     returns the modification time of the file
     """
     open(file_name, 'a').close()
@@ -55,7 +52,6 @@ def test_help_output():
 
 
 class TestInstallNBExtension(TestCase):
-    
     def tempdir(self):
         td = TemporaryDirectory()
         self.tempdirs.append(td)
@@ -112,11 +108,11 @@ class TestInstallNBExtension(TestCase):
         if not os.path.exists(path):
             do_exist = os.listdir(os.path.dirname(path))
             self.fail(u"%s should exist (found %s)" % (path, do_exist))
-    
+
     def assert_not_dir_exists(self, path):
         if os.path.exists(path):
             self.fail(u"%s should not exist" % path)
-    
+
     def assert_installed(self, relative_path, user=False):
         if user:
             nbext = pjoin(self.data_dir, u'nbextensions')
@@ -125,7 +121,7 @@ class TestInstallNBExtension(TestCase):
         self.assert_dir_exists(
             pjoin(nbext, relative_path)
         )
-    
+
     def assert_not_installed(self, relative_path, user=False):
         if user:
             nbext = pjoin(self.data_dir, u'nbextensions')
@@ -134,7 +130,7 @@ class TestInstallNBExtension(TestCase):
         self.assert_not_dir_exists(
             pjoin(nbext, relative_path)
         )
-    
+
     def test_create_data_dir(self):
         """install_nbextension when data_dir doesn't exist"""
         with TemporaryDirectory() as td:
@@ -149,7 +145,7 @@ class TestInstallNBExtension(TestCase):
                         pjoin(basename(self.src), file_name),
                         user=True,
                     )
-    
+
     def test_create_nbextensions_user(self):
         with TemporaryDirectory() as td:
             install_nbextension(self.src, user=True)
@@ -157,7 +153,7 @@ class TestInstallNBExtension(TestCase):
                 pjoin(basename(self.src), u'ƒile'),
                 user=True
             )
-    
+
     def test_create_nbextensions_system(self):
         with TemporaryDirectory() as td:
             self.system_nbext = pjoin(td, u'nbextensions')
@@ -167,17 +163,17 @@ class TestInstallNBExtension(TestCase):
                     pjoin(basename(self.src), u'ƒile'),
                     user=False
                 )
-    
+
     def test_single_file(self):
         file_name = self.files[0]
         install_nbextension(pjoin(self.src, file_name))
         self.assert_installed(file_name)
-    
+
     def test_single_dir(self):
         d = u'∂ir'
         install_nbextension(pjoin(self.src, d))
         self.assert_installed(self.files[-1])
-    
+
     def test_single_dir_trailing_slash(self):
         d = u'∂ir/'
         install_nbextension(pjoin(self.src, d))
@@ -189,18 +185,18 @@ class TestInstallNBExtension(TestCase):
 
     def test_destination_file(self):
         file_name = self.files[0]
-        install_nbextension(pjoin(self.src, file_name), destination = u'ƒiledest')
+        install_nbextension(pjoin(self.src, file_name), destination=u'ƒiledest')
         self.assert_installed(u'ƒiledest')
 
     def test_destination_dir(self):
         d = u'∂ir'
-        install_nbextension(pjoin(self.src, d), destination = u'ƒiledest2')
+        install_nbextension(pjoin(self.src, d), destination=u'ƒiledest2')
         self.assert_installed(pjoin(u'ƒiledest2', u'∂ir2', u'ƒile2'))
-    
+
     def test_install_nbextension(self):
         with self.assertRaises(TypeError):
             install_nbextension(glob.glob(pjoin(self.src, '*')))
-    
+
     def test_overwrite_file(self):
         with TemporaryDirectory() as d:
             fname = u'ƒ.js'
@@ -216,7 +212,7 @@ class TestInstallNBExtension(TestCase):
             install_nbextension(src, overwrite=True)
             with open(dest) as f:
                 self.assertEqual(f.read(), 'overwrite')
-    
+
     def test_overwrite_dir(self):
         with TemporaryDirectory() as src:
             base = basename(src)
@@ -230,7 +226,7 @@ class TestInstallNBExtension(TestCase):
             install_nbextension(src, overwrite=True)
             self.assert_installed(pjoin(base, fname2))
             self.assert_not_installed(pjoin(base, fname))
-    
+
     def test_update_file(self):
         with TemporaryDirectory() as d:
             fname = u'ƒ.js'
@@ -248,7 +244,7 @@ class TestInstallNBExtension(TestCase):
             install_nbextension(src)
             with open(dest) as f:
                 self.assertEqual(f.read(), 'overwrite')
-    
+
     def test_skip_old_file(self):
         with TemporaryDirectory() as d:
             fname = u'ƒ.js'
@@ -258,7 +254,7 @@ class TestInstallNBExtension(TestCase):
             self.assert_installed(fname)
             dest = pjoin(self.system_nbext, fname)
             old_mtime = os.stat(dest).st_mtime
-            
+
             mtime = touch(src, mtime - 100)
             install_nbextension(src)
             new_mtime = os.stat(dest).st_mtime
@@ -272,7 +268,7 @@ class TestInstallNBExtension(TestCase):
             install_nbextension(self.src)
         self.assertEqual(stdout.getvalue(), '')
         self.assertEqual(stderr.getvalue(), '')
-    
+
     def test_install_zip(self):
         path = pjoin(self.src, "myjsext.zip")
         with zipfile.ZipFile(path, 'w') as f:
@@ -281,14 +277,14 @@ class TestInstallNBExtension(TestCase):
         install_nbextension(path)
         self.assert_installed("a.js")
         self.assert_installed(pjoin("foo", "a.js"))
-    
+
     def test_install_tar(self):
         def _add_file(f, fname, buf):
             info = tarfile.TarInfo(fname)
             info.size = len(buf)
             f.addfile(info, BytesIO(buf))
-        
-        for i,ext in enumerate((".tar.gz", ".tgz", ".tar.bz2")):
+
+        for i, ext in enumerate((".tar.gz", ".tgz", ".tar.bz2")):
             path = pjoin(self.src, "myjsext" + ext)
             with tarfile.open(path, 'w') as f:
                 _add_file(f, "b%i.js" % i, b"b();")
@@ -296,10 +292,11 @@ class TestInstallNBExtension(TestCase):
             install_nbextension(path)
             self.assert_installed("b%i.js" % i)
             self.assert_installed(pjoin("foo", "b%i.js" % i))
-    
+
     def test_install_url(self):
         def fake_urlretrieve(url, dest):
             touch(dest)
+
         save_urlretrieve = nbextensions.urlretrieve
         nbextensions.urlretrieve = fake_urlretrieve
         try:
@@ -307,24 +304,24 @@ class TestInstallNBExtension(TestCase):
             self.assert_installed("foo.js")
             install_nbextension("https://example.com/path/to/another/bar.js")
             self.assert_installed("bar.js")
-            install_nbextension("https://example.com/path/to/another/bar.js", 
-                                destination = 'foobar.js')
+            install_nbextension("https://example.com/path/to/another/bar.js",
+                                destination='foobar.js')
             self.assert_installed("foobar.js")
         finally:
             nbextensions.urlretrieve = save_urlretrieve
-    
+
     def test_check_nbextension(self):
         with TemporaryDirectory() as d:
             f = u'ƒ.js'
             src = pjoin(d, f)
             touch(src)
             install_nbextension(src, user=True)
-        
+
         assert check_nbextension(f, user=True)
         assert check_nbextension([f], user=True)
         assert not check_nbextension([f, pjoin('dne', f)], user=True)
-    
-    @dec.skip_win32
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="do not run on windows")
     def test_install_symlink(self):
         with TemporaryDirectory() as d:
             f = u'ƒ.js'
@@ -335,8 +332,8 @@ class TestInstallNBExtension(TestCase):
         assert os.path.islink(dest)
         link = os.readlink(dest)
         self.assertEqual(link, src)
-    
-    @dec.skip_win32
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="do not run on windows")
     def test_overwrite_broken_symlink(self):
         with TemporaryDirectory() as d:
             f = u'ƒ.js'
@@ -352,7 +349,7 @@ class TestInstallNBExtension(TestCase):
         link = os.readlink(dest)
         self.assertEqual(link, src2)
 
-    @dec.skip_win32
+    @pytest.mark.skipif(sys.platform == "win32", reason="do not run on windows")
     def test_install_symlink_destination(self):
         with TemporaryDirectory() as d:
             f = u'ƒ.js'
@@ -365,7 +362,7 @@ class TestInstallNBExtension(TestCase):
         link = os.readlink(dest)
         self.assertEqual(link, src)
 
-    @dec.skip_win32
+    @pytest.mark.skipif(sys.platform == "win32", reason="do not run on windows")
     def test_install_symlink_bad(self):
         with self.assertRaises(ValueError):
             install_nbextension("http://example.com/foo.js", symlink=True)
@@ -396,21 +393,20 @@ class TestInstallNBExtension(TestCase):
             touch(src)
             install_nbextension(src, user=True)
             enable_nbextension(section='notebook', require=u'ƒ')
-        
+
         config_dir = os.path.join(_get_config_dir(user=True), 'nbconfig')
         cm = BaseJSONConfigManager(config_dir=config_dir)
         enabled = cm.get('notebook').get('load_extensions', {}).get(u'ƒ', False)
         assert enabled
-    
+
     def test_nbextension_disable(self):
         self.test_nbextension_enable()
         disable_nbextension(section='notebook', require=u'ƒ')
-        
+
         config_dir = os.path.join(_get_config_dir(user=True), 'nbconfig')
         cm = BaseJSONConfigManager(config_dir=config_dir)
         enabled = cm.get('notebook').get('load_extensions', {}).get(u'ƒ', False)
         assert not enabled
-        
 
     def _mock_extension_spec_meta(self, section='notebook'):
         return {
@@ -427,52 +423,52 @@ class TestInstallNBExtension(TestCase):
 
         class mock():
             __file__ = outer_file
-            
+
             @staticmethod
             def _jupyter_nbextension_paths():
                 return [meta]
-        
+
         import sys
         sys.modules['mockextension'] = mock
-        
+
     def test_nbextensionpy_files(self):
         self._inject_mock_extension()
         install_nbextension_python('mockextension')
-        
+
         assert check_nbextension('_mockdestination/index.js')
         assert check_nbextension(['_mockdestination/index.js'])
-        
+
     def test_nbextensionpy_user_files(self):
         self._inject_mock_extension()
         install_nbextension_python('mockextension', user=True)
-        
+
         assert check_nbextension('_mockdestination/index.js', user=True)
         assert check_nbextension(['_mockdestination/index.js'], user=True)
-        
+
     def test_nbextensionpy_uninstall_files(self):
         self._inject_mock_extension()
         install_nbextension_python('mockextension', user=True)
         uninstall_nbextension_python('mockextension', user=True)
-        
+
         assert not check_nbextension('_mockdestination/index.js')
         assert not check_nbextension(['_mockdestination/index.js'])
-        
+
     def test_nbextensionpy_enable(self):
         self._inject_mock_extension('notebook')
         install_nbextension_python('mockextension', user=True)
         enable_nbextension_python('mockextension')
-        
+
         config_dir = os.path.join(_get_config_dir(user=True), 'nbconfig')
         cm = BaseJSONConfigManager(config_dir=config_dir)
         enabled = cm.get('notebook').get('load_extensions', {}).get('_mockdestination/index', False)
         assert enabled
-        
+
     def test_nbextensionpy_disable(self):
         self._inject_mock_extension('notebook')
         install_nbextension_python('mockextension', user=True)
         enable_nbextension_python('mockextension')
         disable_nbextension_python('mockextension', user=True)
-        
+
         config_dir = os.path.join(_get_config_dir(user=True), 'nbconfig')
         cm = BaseJSONConfigManager(config_dir=config_dir)
         enabled = cm.get('notebook').get('load_extensions', {}).get('_mockdestination/index', False)
@@ -515,4 +511,3 @@ class TestInstallNBExtension(TestCase):
     def test_nbextension_validate_bad(self):
         warnings = validate_nbextension("this-doesn't-exist")
         self.assertNotEqual([], warnings, warnings)
-

--- a/dfkernel/tests/test_notebookapp.py
+++ b/dfkernel/tests/test_notebookapp.py
@@ -9,12 +9,9 @@ from subprocess import Popen, PIPE, STDOUT
 import sys
 from tempfile import NamedTemporaryFile
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch # py2
+from unittest.mock import patch
 
-import nose.tools as nt
+import pytest
 
 from traitlets.tests.utils import check_help_all_output
 
@@ -24,6 +21,8 @@ from traitlets import TraitError
 from notebook import notebookapp, __version__
 from notebook.auth.security import passwd_check
 NotebookApp = notebookapp.NotebookApp
+
+from .launchnotebook import NotebookTestBase, UNIXSocketNotebookTestBase
 
 
 def test_help_output():
@@ -38,11 +37,11 @@ def test_server_info_file():
     nbapp.initialize(argv=[])
     nbapp.write_server_info_file()
     servers = get_servers()
-    nt.assert_equal(len(servers), 1)
-    nt.assert_equal(servers[0]['port'], nbapp.port)
-    nt.assert_equal(servers[0]['url'], nbapp.connection_url)
+    assert len(servers) == 1
+    assert servers[0]['port'] == nbapp.port
+    assert servers[0]['url'] == nbapp.connection_url
     nbapp.remove_server_info_file()
-    nt.assert_equal(get_servers(), [])
+    assert get_servers() == []
 
     # The ENOENT error should be silenced.
     nbapp.remove_server_info_file()
@@ -50,43 +49,43 @@ def test_server_info_file():
 def test_nb_dir():
     with TemporaryDirectory() as td:
         app = NotebookApp(notebook_dir=td)
-        nt.assert_equal(app.notebook_dir, td)
+        assert app.notebook_dir == td
 
 def test_no_create_nb_dir():
     with TemporaryDirectory() as td:
         nbdir = os.path.join(td, 'notebooks')
         app = NotebookApp()
-        with nt.assert_raises(TraitError):
+        with pytest.raises(TraitError):
             app.notebook_dir = nbdir
 
 def test_missing_nb_dir():
     with TemporaryDirectory() as td:
         nbdir = os.path.join(td, 'notebook', 'dir', 'is', 'missing')
         app = NotebookApp()
-        with nt.assert_raises(TraitError):
+        with pytest.raises(TraitError):
             app.notebook_dir = nbdir
 
 def test_invalid_nb_dir():
     with NamedTemporaryFile() as tf:
         app = NotebookApp()
-        with nt.assert_raises(TraitError):
+        with pytest.raises(TraitError):
             app.notebook_dir = tf
 
 def test_nb_dir_with_slash():
     with TemporaryDirectory(suffix="_slash" + os.sep) as td:
         app = NotebookApp(notebook_dir=td)
-        nt.assert_false(app.notebook_dir.endswith(os.sep))
+        assert not app.notebook_dir.endswith(os.sep)
 
 def test_nb_dir_root():
     root = os.path.abspath(os.sep) # gets the right value on Windows, Posix
     app = NotebookApp(notebook_dir=root)
-    nt.assert_equal(app.notebook_dir, root)
+    assert app.notebook_dir == root
 
 def test_generate_config():
     with TemporaryDirectory() as td:
         app = NotebookApp(config_dir=td)
         app.initialize(['--generate-config', '--allow-root'])
-        with nt.assert_raises(NoStart):
+        with pytest.raises(NoStart):
             app.start()
         assert os.path.exists(os.path.join(td, 'jupyter_notebook_config.py'))
 
@@ -101,7 +100,7 @@ def test_pep440_version():
         '1.2.3.dev1.post2',
         ]:
         def loc():
-            with nt.assert_raises(ValueError):
+            with pytest.raises(ValueError):
                 raise_on_bad_version(version)
         yield loc
 
@@ -137,13 +136,13 @@ def test_notebook_password():
             app.start()
             nb = NotebookApp()
             nb.load_config_file()
-            nt.assert_not_equal(nb.password, '')
+            assert nb.password != ''
             passwd_check(nb.password, password)
 
 class TestingStopApp(notebookapp.NbserverStopApp):
     """For testing the logic of NbserverStopApp."""
     def __init__(self, **kwargs):
-        super(TestingStopApp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.servers_shut_down = []
 
     def shutdown_server(self, server):
@@ -172,14 +171,65 @@ def test_notebook_stop():
         app = TestingStopApp()
         app.initialize(['105'])
         app.start()
-    nt.assert_equal(len(app.servers_shut_down), 1)
-    nt.assert_equal(app.servers_shut_down[0]['port'], 105)
+    assert len(app.servers_shut_down) == 1
+    assert app.servers_shut_down[0]['port'] == 105
 
     # test no match
     with mock_servers, patch('os.kill') as os_kill:
         app = TestingStopApp()
         app.initialize(['999'])
-        with nt.assert_raises(SystemExit) as exc:
+        with pytest.raises(SystemExit) as exc:
             app.start()
-        nt.assert_equal(exc.exception.code, 1)
-    nt.assert_equal(len(app.servers_shut_down), 0)
+        assert exc.value.code == 1
+    assert len(app.servers_shut_down) == 0
+
+
+class NotebookAppTests(NotebookTestBase):
+    def test_list_running_servers(self):
+        servers = list(notebookapp.list_running_servers())
+        assert len(servers) >= 1
+        assert self.port in {info['port'] for info in servers}
+
+    def test_log_json_default(self):
+        self.assertFalse(self.notebook.log_json)
+
+    def test_validate_log_json(self):
+        self.assertFalse(self.notebook._validate_log_json(dict(value=False)))
+
+
+# UNIX sockets aren't available on Windows.
+if not sys.platform.startswith('win'):
+    class NotebookUnixSocketTests(UNIXSocketNotebookTestBase):
+        def test_run(self):
+            self.fetch_url(self.base_url() + 'api/contents')
+
+        def test_list_running_sock_servers(self):
+            servers = list(notebookapp.list_running_servers())
+            assert len(servers) >= 1
+            assert self.sock in {info['sock'] for info in servers}
+
+
+class NotebookAppJSONLoggingTests(NotebookTestBase):
+    """Tests for when json logging is enabled."""
+    @classmethod
+    def setup_class(cls):
+        super(NotebookAppJSONLoggingTests, cls).setup_class()
+        try:
+            import json_logging
+            cls.json_logging_available = True
+        except ImportError:
+            cls.json_logging_available = False
+
+    @classmethod
+    def get_patch_env(cls):
+        test_env = super(NotebookAppJSONLoggingTests, cls).get_patch_env()
+        test_env.update({'JUPYTER_ENABLE_JSON_LOGGING': 'true'})
+        return test_env
+
+    def test_log_json_enabled(self):
+        self.assertTrue(self.notebook._default_log_json())
+
+    def test_validate_log_json(self):
+        self.assertEqual(
+            self.notebook._validate_log_json(dict(value=True)),
+            self.json_logging_available)

--- a/dfkernel/tests/test_paths.py
+++ b/dfkernel/tests/test_paths.py
@@ -1,16 +1,6 @@
-
 import re
-import nose.tools as nt
 
 from notebook.base.handlers import path_regex
-
-try: # py3
-    assert_regex = nt.assert_regex
-    assert_not_regex = nt.assert_not_regex
-except AttributeError: # py2
-    assert_regex = nt.assert_regexp_matches
-    assert_not_regex = nt.assert_not_regexp_matches
-
 
 # build regexps that tornado uses:
 path_pat = re.compile('^' + '/x%s' % path_regex + '$')
@@ -24,7 +14,9 @@ def test_path_regex():
         '/x/foo/bar',
         '/x/foo/bar.txt',
     ):
-        assert_regex(path, path_pat)
+        print(type(path))
+        print(type(path_pat))
+        assert re.match(path_pat, path)
 
 def test_path_regex_bad():
     for path in (
@@ -37,4 +29,4 @@ def test_path_regex_bad():
         '/y',
         '/y/x/foo',
     ):
-        assert_not_regex(path, path_pat)
+        assert not re.match(path_pat, path)

--- a/dfkernel/tests/test_serialize.py
+++ b/dfkernel/tests/test_serialize.py
@@ -1,210 +1,24 @@
-"""test serialization tools"""
+"""Test serialize/deserialize messages with buffers"""
 
-# Copyright (c) IPython Development Team.
-# Distributed under the terms of the Modified BSD License.
+import os
 
-import pickle
-from collections import namedtuple
+from jupyter_client.session import Session
+from notebook.base.zmqhandlers import (
+    serialize_binary_message,
+    deserialize_binary_message,
+)
 
-import nose.tools as nt
+def test_serialize_binary():
+    s = Session()
+    msg = s.msg('data_pub', content={'a': 'b'})
+    msg['buffers'] = [ memoryview(os.urandom(3)) for i in range(3) ]
+    bmsg = serialize_binary_message(msg)
+    assert isinstance(bmsg, bytes)
 
-from ipykernel.serialize import serialize_object, deserialize_object
-from IPython.testing import decorators as dec
-from ipykernel.pickleutil import CannedArray, CannedClass, interactive
-from ipython_genutils.py3compat import iteritems
-
-#-------------------------------------------------------------------------------
-# Globals and Utilities
-#-------------------------------------------------------------------------------
-
-def roundtrip(obj):
-    """roundtrip an object through serialization"""
-    bufs = serialize_object(obj)
-    obj2, remainder = deserialize_object(bufs)
-    nt.assert_equals(remainder, [])
-    return obj2
-
-
-SHAPES = ((100,), (1024,10), (10,8,6,5), (), (0,))
-DTYPES = ('uint8', 'float64', 'int32', [('g', 'float32')], '|S10')
-
-#-------------------------------------------------------------------------------
-# Tests
-#-------------------------------------------------------------------------------
-
-def new_array(shape, dtype):
-    import numpy
-    return numpy.random.random(shape).astype(dtype)
-
-def test_roundtrip_simple():
-    for obj in [
-        'hello',
-        dict(a='b', b=10),
-        [1,2,'hi'],
-        (b'123', 'hello'),
-    ]:
-        obj2 = roundtrip(obj)
-        nt.assert_equal(obj, obj2)
-
-def test_roundtrip_nested():
-    for obj in [
-        dict(a=range(5), b={1:b'hello'}),
-        [range(5),[range(3),(1,[b'whoda'])]],
-    ]:
-        obj2 = roundtrip(obj)
-        nt.assert_equal(obj, obj2)
-
-def test_roundtrip_buffered():
-    for obj in [
-        dict(a=b"x"*1025),
-        b"hello"*500,
-        [b"hello"*501, 1,2,3]
-    ]:
-        bufs = serialize_object(obj)
-        nt.assert_equal(len(bufs), 2)
-        obj2, remainder = deserialize_object(bufs)
-        nt.assert_equal(remainder, [])
-        nt.assert_equal(obj, obj2)
-
-def test_roundtrip_memoryview():
-    b = b'asdf' * 1025
-    view = memoryview(b)
-    bufs = serialize_object(view)
-    nt.assert_equal(len(bufs), 2)
-    v2, remainder = deserialize_object(bufs)
-    nt.assert_equal(remainder, [])
-    nt.assert_equal(v2.tobytes(), b)
-
-@dec.skip_without('numpy')
-def test_numpy():
-    import numpy
-    from numpy.testing.utils import assert_array_equal
-    for shape in SHAPES:
-        for dtype in DTYPES:
-            A = new_array(shape, dtype=dtype)
-            bufs = serialize_object(A)
-            bufs = [memoryview(b) for b in bufs]
-            B, r = deserialize_object(bufs)
-            nt.assert_equal(r, [])
-            nt.assert_equal(A.shape, B.shape)
-            nt.assert_equal(A.dtype, B.dtype)
-            assert_array_equal(A,B)
-
-@dec.skip_without('numpy')
-def test_recarray():
-    import numpy
-    from numpy.testing.utils import assert_array_equal
-    for shape in SHAPES:
-        for dtype in [
-            [('f', float), ('s', '|S10')],
-            [('n', int), ('s', '|S1'), ('u', 'uint32')],
-        ]:
-            A = new_array(shape, dtype=dtype)
-
-            bufs = serialize_object(A)
-            B, r = deserialize_object(bufs)
-            nt.assert_equal(r, [])
-            nt.assert_equal(A.shape, B.shape)
-            nt.assert_equal(A.dtype, B.dtype)
-            assert_array_equal(A,B)
-
-@dec.skip_without('numpy')
-def test_numpy_in_seq():
-    import numpy
-    from numpy.testing.utils import assert_array_equal
-    for shape in SHAPES:
-        for dtype in DTYPES:
-            A = new_array(shape, dtype=dtype)
-            bufs = serialize_object((A,1,2,b'hello'))
-            canned = pickle.loads(bufs[0])
-            nt.assert_is_instance(canned[0], CannedArray)
-            tup, r = deserialize_object(bufs)
-            B = tup[0]
-            nt.assert_equal(r, [])
-            nt.assert_equal(A.shape, B.shape)
-            nt.assert_equal(A.dtype, B.dtype)
-            assert_array_equal(A,B)
-
-@dec.skip_without('numpy')
-def test_numpy_in_dict():
-    import numpy
-    from numpy.testing.utils import assert_array_equal
-    for shape in SHAPES:
-        for dtype in DTYPES:
-            A = new_array(shape, dtype=dtype)
-            bufs = serialize_object(dict(a=A,b=1,c=range(20)))
-            canned = pickle.loads(bufs[0])
-            nt.assert_is_instance(canned['a'], CannedArray)
-            d, r = deserialize_object(bufs)
-            B = d['a']
-            nt.assert_equal(r, [])
-            nt.assert_equal(A.shape, B.shape)
-            nt.assert_equal(A.dtype, B.dtype)
-            assert_array_equal(A,B)
-
-def test_class():
-    @interactive
-    class C(object):
-        a=5
-    bufs = serialize_object(dict(C=C))
-    canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned['C'], CannedClass)
-    d, r = deserialize_object(bufs)
-    C2 = d['C']
-    nt.assert_equal(C2.a, C.a)
-
-def test_class_oldstyle():
-    @interactive
-    class C:
-        a=5
-
-    bufs = serialize_object(dict(C=C))
-    canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned['C'], CannedClass)
-    d, r = deserialize_object(bufs)
-    C2 = d['C']
-    nt.assert_equal(C2.a, C.a)
-
-def test_tuple():
-    tup = (lambda x:x, 1)
-    bufs = serialize_object(tup)
-    canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned, tuple)
-    t2, r = deserialize_object(bufs)
-    nt.assert_equal(t2[0](t2[1]), tup[0](tup[1]))
-
-point = namedtuple('point', 'x y')
-
-def test_namedtuple():
-    p = point(1,2)
-    bufs = serialize_object(p)
-    canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned, point)
-    p2, r = deserialize_object(bufs, globals())
-    nt.assert_equal(p2.x, p.x)
-    nt.assert_equal(p2.y, p.y)
-
-def test_list():
-    lis = [lambda x:x, 1]
-    bufs = serialize_object(lis)
-    canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned, list)
-    l2, r = deserialize_object(bufs)
-    nt.assert_equal(l2[0](l2[1]), lis[0](lis[1]))
-
-def test_class_inheritance():
-    @interactive
-    class C(object):
-        a=5
-
-    @interactive
-    class D(C):
-        b=10
-
-    bufs = serialize_object(dict(D=D))
-    canned = pickle.loads(bufs[0])
-    nt.assert_is_instance(canned['D'], CannedClass)
-    d, r = deserialize_object(bufs)
-    D2 = d['D']
-    nt.assert_equal(D2.a, D.a)
-    nt.assert_equal(D2.b, D.b)
+def test_deserialize_binary():
+    s = Session()
+    msg = s.msg('data_pub', content={'a': 'b'})
+    msg['buffers'] = [ memoryview(os.urandom(2)) for i in range(3) ]
+    bmsg = serialize_binary_message(msg)
+    msg2 = deserialize_binary_message(bmsg)
+    assert msg2 == msg

--- a/dfkernel/tests/test_serverextensions.py
+++ b/dfkernel/tests/test_serverextensions.py
@@ -2,10 +2,7 @@ import imp
 import os
 import sys
 from unittest import TestCase
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch # py2
+from unittest.mock import patch
 
 from ipython_genutils.tempdir import TemporaryDirectory
 from ipython_genutils import py3compat
@@ -19,11 +16,7 @@ from notebook import nbextensions, serverextensions, extensions
 from notebook.notebookapp import NotebookApp
 from notebook.nbextensions import _get_config_dir
 
-if sys.version_info > (3,):
-    from types import SimpleNamespace
-else:
-    class SimpleNamespace(object):
-        pass
+from types import SimpleNamespace
 
 from collections import OrderedDict
 
@@ -35,7 +28,9 @@ def test_help_output():
     check_help_all_output('notebook.serverextensions', ['install'])
     check_help_all_output('notebook.serverextensions', ['uninstall'])
 
+
 outer_file = __file__
+
 
 class MockExtensionModule(object):
     __file__ = outer_file
@@ -47,13 +42,12 @@ class MockExtensionModule(object):
         }]
 
     loaded = False
-    
+
     def load_jupyter_server_extension(self, app):
         self.loaded = True
 
 
 class MockEnvTestCase(TestCase):
-    
     def tempdir(self):
         td = TemporaryDirectory()
         self.tempdirs.append(td)
@@ -70,7 +64,7 @@ class MockEnvTestCase(TestCase):
         self.system_config_dir = os.path.join(self.test_dir, 'system_config')
         self.system_path = [self.system_data_dir]
         self.system_config_path = [self.system_config_dir]
-        
+
         self.patches = []
         p = patch.dict('os.environ', {
             'JUPYTER_CONFIG_DIR': self.config_dir,
@@ -79,17 +73,17 @@ class MockEnvTestCase(TestCase):
         self.patches.append(p)
         for mod in (paths, nbextensions):
             p = patch.object(mod,
-                'SYSTEM_JUPYTER_PATH', self.system_path)
+                             'SYSTEM_JUPYTER_PATH', self.system_path)
             self.patches.append(p)
             p = patch.object(mod,
-                'ENV_JUPYTER_PATH', [])
+                             'ENV_JUPYTER_PATH', [])
             self.patches.append(p)
         for mod in (paths, extensions):
             p = patch.object(mod,
-                'SYSTEM_CONFIG_PATH', self.system_config_path)
+                             'SYSTEM_CONFIG_PATH', self.system_config_path)
             self.patches.append(p)
             p = patch.object(mod,
-                'ENV_CONFIG_PATH', [])
+                             'ENV_CONFIG_PATH', [])
             self.patches.append(p)
         for p in self.patches:
             p.start()
@@ -98,7 +92,7 @@ class MockEnvTestCase(TestCase):
         self.assertEqual(paths.jupyter_config_path(), [self.config_dir] + self.system_config_path)
         self.assertEqual(extensions._get_config_dir(user=False), self.system_config_dir)
         self.assertEqual(paths.jupyter_path(), [self.data_dir] + self.system_path)
-    
+
     def tearDown(self):
         for modulename in self._mock_extensions:
             sys.modules.pop(modulename)
@@ -109,8 +103,8 @@ class MockEnvTestCase(TestCase):
         self._mock_extensions.append(modulename)
         return ext
 
-class TestInstallServerExtension(MockEnvTestCase):
 
+class TestInstallServerExtension(MockEnvTestCase):
     def _get_config(self, user=True):
         cm = BaseJSONConfigManager(config_dir=_get_config_dir(user))
         data = cm.get("jupyter_notebook_config")
@@ -147,6 +141,7 @@ class TestInstallServerExtension(MockEnvTestCase):
         toggle_serverextension_python('mockext_both', enabled=False, user=True)
 
         app = NotebookApp(nbserver_extensions={'mockext_py': True})
+        app.init_server_extension_config()
         app.init_server_extensions()
 
         assert mock_user.loaded
@@ -161,7 +156,7 @@ class TestOrderedServerExtension(MockEnvTestCase):
     """
 
     def setUp(self):
-        super(TestOrderedServerExtension, self).setUp()
+        super().setUp()
         mockextension1 = SimpleNamespace()
         mockextension2 = SimpleNamespace()
 
@@ -181,14 +176,13 @@ class TestOrderedServerExtension(MockEnvTestCase):
         sys.modules['mockextension1'] = mockextension1
 
     def tearDown(self):
-        super(TestOrderedServerExtension, self).tearDown()
+        super().tearDown()
         del sys.modules['mockextension2']
         del sys.modules['mockextension1']
 
-
     def test_load_ordered(self):
         app = NotebookApp()
-        app.nbserver_extensions = OrderedDict([('mockextension2',True),('mockextension1',True)])
+        app.nbserver_extensions = OrderedDict([('mockextension2', True), ('mockextension1', True)])
 
         app.init_server_extensions()
 

--- a/dfkernel/tests/test_utils.py
+++ b/dfkernel/tests/test_utils.py
@@ -5,8 +5,9 @@
 
 import ctypes
 import os
+import sys
 
-import nose.tools as nt
+import pytest
 
 from traitlets.tests.utils import check_help_all_output
 from notebook.utils import url_escape, url_unescape, is_hidden, is_file_hidden
@@ -26,62 +27,61 @@ def test_url_escape():
     # changes path or notebook name with special characters to url encoding
     # these tests specifically encode paths with spaces
     path = url_escape('/this is a test/for spaces/')
-    nt.assert_equal(path, '/this%20is%20a%20test/for%20spaces/')
+    assert path == '/this%20is%20a%20test/for%20spaces/'
 
     path = url_escape('notebook with space.ipynb')
-    nt.assert_equal(path, 'notebook%20with%20space.ipynb')
+    assert path == 'notebook%20with%20space.ipynb'
 
     path = url_escape('/path with a/notebook and space.ipynb')
-    nt.assert_equal(path, '/path%20with%20a/notebook%20and%20space.ipynb')
-    
+    assert path == '/path%20with%20a/notebook%20and%20space.ipynb'
+
     path = url_escape('/ !@$#%^&* / test %^ notebook @#$ name.ipynb')
-    nt.assert_equal(path,
-        '/%20%21%40%24%23%25%5E%26%2A%20/%20test%20%25%5E%20notebook%20%40%23%24%20name.ipynb')
+    assert path == '/%20%21%40%24%23%25%5E%26%2A%20/%20test%20%25%5E%20notebook%20%40%23%24%20name.ipynb'
 
 def test_url_unescape():
 
     # decodes a url string to a plain string
     # these tests decode paths with spaces
     path = url_unescape('/this%20is%20a%20test/for%20spaces/')
-    nt.assert_equal(path, '/this is a test/for spaces/')
+    assert path == '/this is a test/for spaces/'
 
     path = url_unescape('notebook%20with%20space.ipynb')
-    nt.assert_equal(path, 'notebook with space.ipynb')
+    assert path == 'notebook with space.ipynb'
 
     path = url_unescape('/path%20with%20a/notebook%20and%20space.ipynb')
-    nt.assert_equal(path, '/path with a/notebook and space.ipynb')
+    assert path == '/path with a/notebook and space.ipynb'
 
     path = url_unescape(
         '/%20%21%40%24%23%25%5E%26%2A%20/%20test%20%25%5E%20notebook%20%40%23%24%20name.ipynb')
-    nt.assert_equal(path, '/ !@$#%^&* / test %^ notebook @#$ name.ipynb')
+    assert path == '/ !@$#%^&* / test %^ notebook @#$ name.ipynb'
 
 def test_is_hidden():
     with TemporaryDirectory() as root:
         subdir1 = os.path.join(root, 'subdir')
         os.makedirs(subdir1)
-        nt.assert_equal(is_hidden(subdir1, root), False)
-        nt.assert_equal(is_file_hidden(subdir1), False)
+        assert is_hidden(subdir1, root) == False
+        assert is_file_hidden(subdir1) == False
 
         subdir2 = os.path.join(root, '.subdir2')
         os.makedirs(subdir2)
-        nt.assert_equal(is_hidden(subdir2, root), True)
-        nt.assert_equal(is_file_hidden(subdir2), True)#
+        assert is_hidden(subdir2, root) == True
+        assert is_file_hidden(subdir2) == True
         # root dir is always visible
-        nt.assert_equal(is_hidden(subdir2, subdir2), False)
+        assert is_hidden(subdir2, subdir2) == False
 
         subdir34 = os.path.join(root, 'subdir3', '.subdir4')
         os.makedirs(subdir34)
-        nt.assert_equal(is_hidden(subdir34, root), True)
-        nt.assert_equal(is_hidden(subdir34), True)
+        assert is_hidden(subdir34, root) == True
+        assert is_hidden(subdir34) == True
 
         subdir56 = os.path.join(root, '.subdir5', 'subdir6')
         os.makedirs(subdir56)
-        nt.assert_equal(is_hidden(subdir56, root), True)
-        nt.assert_equal(is_hidden(subdir56), True)
-        nt.assert_equal(is_file_hidden(subdir56), False)
-        nt.assert_equal(is_file_hidden(subdir56, os.stat(subdir56)), False)
+        assert is_hidden(subdir56, root) == True
+        assert is_hidden(subdir56) == True
+        assert is_file_hidden(subdir56) == False
+        assert is_file_hidden(subdir56, os.stat(subdir56)) == False
 
-@skip_if_not_win32
+@pytest.mark.skipif(sys.platform != "win32", reason="run on windows only")
 def test_is_hidden_win32():
     with TemporaryDirectory() as root:
         root = cast_unicode(root)
@@ -92,4 +92,3 @@ def test_is_hidden_win32():
         print(r)
         assert is_hidden(subdir1, root)
         assert is_file_hidden(subdir1)
-


### PR DESCRIPTION
This includes a monkey patch to ensure that earlier versions of Python still work with dfkernel.

This also includes some updates to tests that are currently failing due to using older testing frameworks.