### PR TITLE
Add fix for cells that export only libraries

### DIFF
--- a/dfkernel/dataflow.py
+++ b/dfkernel/dataflow.py
@@ -233,6 +233,8 @@ class DataflowHistoryManager(object):
     def __getitem__(self, k):
         res = self.get_item(k)
         if isinstance(res, LinkedResult):
+            if res.__tuple__() is None:
+                return res
             return res.__tuple__()
         return res
 


### PR DESCRIPTION
Rather simple fix to ensure cells that only export libraries can resolve names properly when referenced in ```Out[aaa]['np']``` format for example when referencing the cell below

```
In[aaa]: import numpy as np
np: <library>
```