### PR TITLE
Restore internal nodes

### DIFF
--- a/dfkernel/zmqshell.py
+++ b/dfkernel/zmqshell.py
@@ -566,10 +566,10 @@ class ZMQInteractiveShell(ipykernel.zmqshell.ZMQInteractiveShell):
         # FIXME evaluate whether internalnodes is required for anything
         # -- I don't think it is, only used in graph stuff -DK
         #
-        # internalnodes = []
-        # for node in ast.walk(code_ast):
-        #     if (isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)):
-        #         internalnodes.append(node.id)
+        internalnodes = []
+        for node in ast.walk(ast.parse(transformed_cell)):
+            if (isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)):
+                internalnodes.append(node.id)
 
         # before run_ast_nodes runs, have some code to run, used to be in run_cell
         # but should be able to live in run_ast_nodes...
@@ -648,7 +648,7 @@ class ZMQInteractiveShell(ipykernel.zmqshell.ZMQInteractiveShell):
                 result.links = self.dataflow_history_manager.raw_semantic_upstream(uuid)
                 result.deleted_cells = self.dataflow_history_manager.deleted_cells
                 # FIXME decide if this is worth keeping
-                result.internal_nodes = []
+                result.internal_nodes = internalnodes
                 # print("GOT DELETED CELLS:", result.deleted_cells, file=sys.__stdout__)
                 self.dataflow_history_manager.deleted_cells = []
 

--- a/dfkernel/zmqshell.py
+++ b/dfkernel/zmqshell.py
@@ -563,6 +563,7 @@ class ZMQInteractiveShell(ipykernel.zmqshell.ZMQInteractiveShell):
         result_deleted_cells = self.dataflow_history_manager.deleted_cells
         self.dataflow_history_manager.deleted_cells = []
 
+        #FIXME low priority possibly change how these are calculated, this can probably be moved elsewhere
         internalnodes = []
         for node in ast.walk(ast.parse(transformed_cell)):
             if (isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)):
@@ -644,7 +645,7 @@ class ZMQInteractiveShell(ipykernel.zmqshell.ZMQInteractiveShell):
                 result.cells = cells
                 result.links = self.dataflow_history_manager.raw_semantic_upstream(uuid)
                 result.deleted_cells = self.dataflow_history_manager.deleted_cells
-                # FIXME decide if this is worth keeping
+
                 result.internal_nodes = internalnodes
                 # print("GOT DELETED CELLS:", result.deleted_cells, file=sys.__stdout__)
                 self.dataflow_history_manager.deleted_cells = []

--- a/dfkernel/zmqshell.py
+++ b/dfkernel/zmqshell.py
@@ -563,9 +563,6 @@ class ZMQInteractiveShell(ipykernel.zmqshell.ZMQInteractiveShell):
         result_deleted_cells = self.dataflow_history_manager.deleted_cells
         self.dataflow_history_manager.deleted_cells = []
 
-        # FIXME evaluate whether internalnodes is required for anything
-        # -- I don't think it is, only used in graph stuff -DK
-        #
         internalnodes = []
         for node in ast.walk(ast.parse(transformed_cell)):
             if (isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)):


### PR DESCRIPTION
This is necessary for the re-addition of the dependency viewer in the notebook extension.

Do we want to modify this in any way or move it elsewhere?