### PR TITLE
Allow for compatibility with ipykernel recent versions

### DIFF
--- a/dfkernel/iostream.py
+++ b/dfkernel/iostream.py
@@ -18,7 +18,10 @@ class OutStream(ipykernel.iostream.OutStream):
         """
 
         self._flush_pending = False
-        data = self._flush_buffer()
+        if callable(getattr(self,"_flush_buffer",None)):
+            data = self._flush_buffer()
+        else:
+            data = self._flush_buffers()
         if data:
             # FIXME: this disables Session's fork-safe check,
             # since pub_thread is itself fork-safe.

--- a/dfkernel/iostream.py
+++ b/dfkernel/iostream.py
@@ -18,10 +18,10 @@ class OutStream(ipykernel.iostream.OutStream):
         """
 
         self._flush_pending = False
-        if callable(getattr(self,"_flush_buffer",None)):
-            data = self._flush_buffer()
-        else:
+        if callable(getattr(self,"_flush_buffers",None)):
             data = self._flush_buffers()
+        else:
+            data = self._flush_buffer()
         if data:
             # FIXME: this disables Session's fork-safe check,
             # since pub_thread is itself fork-safe.


### PR DESCRIPTION
This should be a rather simple fix to allow for the use of older and newer versions of ipykernel since they changed _flush_buffer() into _flush_buffers() in more recent versions.