### PR TITLE
Rewrite OutStream with execution count addition

### DIFF
--- a/dfkernel/iostream.py
+++ b/dfkernel/iostream.py
@@ -1,63 +1,19 @@
 import ipykernel.iostream
-from ipykernel.iostream import *
 
 class OutStream(ipykernel.iostream.OutStream):
     def __init__(self, *args, **kwargs):
-        super(OutStream, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.execution_count = None
+        # this has to be added on the iopubthread...
+        # otherwise, _flush will not see it
+        self.pub_thread.schedule(self._add_uuid_hook)
+
+    def uuid_hook(self, msg):
+        msg['content']['execution_count'] = self.get_execution_count()
+        return msg
+
+    def _add_uuid_hook(self):
+        self.register_hook(self.uuid_hook)
 
     def get_execution_count(self):
         raise NotImplementedError("Should be added by the kernelapp");
-
-    # Update _flush to send the execution_count back with output
-    def _flush(self):
-        """This is where the actual send happens.
-
-        _flush should generally be called in the IO thread,
-        unless the thread has been destroyed (e.g. forked subprocess).
-        """
-
-        self._flush_pending = False
-        self._subprocess_flush_pending = False
-
-        if self.echo is not None:
-            try:
-                self.echo.flush()
-            except OSError as e:
-                if self.echo is not sys.__stderr__:
-                    print(f"Flush failed: {e}", file=sys.__stderr__)
-
-        if callable(getattr(self,"_flush_buffers",None)):
-            for parent, data in self._flush_buffers():
-                # FIXME: this disables Session's fork-safe check,
-                # since pub_thread is itself fork-safe.
-                # There should be a better way to do this.
-                self.session.pid = os.getpid()
-                content = {"name": self.name, "text": data,'execution_count': self.get_execution_count()}
-                msg = self.session.msg("stream", content, parent=parent)
-
-                # Each transform either returns a new
-                # message or None. If None is returned,
-                # the message has been 'used' and we return.
-                for hook in self._hooks:
-                    msg = hook(msg)
-                    if msg is None:
-                        return
-
-                self.session.send(
-                    self.pub_thread,
-                    msg,
-                    ident=self.topic,
-                )
-
-        else:
-            data = self._flush_buffer()
-            if data:
-                # FIXME: this disables Session's fork-safe check,
-                # since pub_thread is itself fork-safe.
-                # There should be a better way to do this.
-                self.session.pid = os.getpid()
-                content = {u'name': self.name, u'text': data,
-                        u'execution_count': self.get_execution_count()}
-                self.session.send(self.pub_thread, u'stream', content=content,
-                                parent=self.parent_header, ident=self.topic)


### PR DESCRIPTION
We can remove the rewrite of _flush by taking advantage of the hooks, but need to do this on the iopub thread