### PR TITLE
Fix the kernel installation issue due to incorrect path

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,5 +1,4 @@
 """A custom hatch build hook for ipykernel."""
-import os
 import shutil
 import sys
 from pathlib import Path
@@ -12,11 +11,8 @@ class CustomHook(BuildHookInterface):
 
     def initialize(self, version, build_data):
         """Initialize the hook."""
-        # here = Path(__file__).parent.resolve()
-        # sys.path.insert(0, str(here))
-        # from dfkernel.kernelspec import make_ipkernel_cmd, write_kernel_spec
-        here = Path(__file__).parent.resolve() / "dfkernel"
-        sys.path.insert(0, str(here))
+        here = Path(__file__).parent.resolve()
+        sys.path.insert(0, str(here / "dfkernel"))
         from kernelspec import make_ipkernel_cmd, write_kernel_spec
 
         overrides = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ path = "dfkernel/_version.py"
 [tool.hatch.build.hooks.custom]
 
 [tool.hatch.build.targets.wheel.shared-data]
-"data_kernelspec" = "share/jupyter/kernels/dfkernel"
+"data_kernelspec" = "share/jupyter/kernels/dfpython3"
 
 [tool.hatch.build.force-include]
 "./dfkernel_launcher.py" = "dfkernel_launcher.py"


### PR DESCRIPTION
Fixes #90

There were two issues: (1) the data_kernelspec path wasn't correct due to the change to dfkernel subdir, and (2) the install path was "dfkernel" instead of "dfpython3".